### PR TITLE
feat: automatic C2C subscription cleanup on 409 Conflict

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MESSAGES CONTROL]
+# Disable too-many-positional-arguments for pylint 3.1.0 compatibility
+# This warning is only available in pylint 3.1.0+, but it conflicts with our code structure
+disable=too-many-positional-arguments
+

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-# Disable too-many-positional-arguments for pylint 3.1.0 compatibility
+# Disable R0917 (too-many-positional-arguments) for pylint 3.1.0 compatibility
 # This warning is only available in pylint 3.1.0+, but it conflicts with our code structure
-disable=too-many-positional-arguments
+disable=R0917
 

--- a/custom_components/bticino_x8000/__init__.py
+++ b/custom_components/bticino_x8000/__init__.py
@@ -101,7 +101,7 @@ async def async_setup_entry(  # pylint: disable=too-many-statements
                                     endpoint,
                                 )
 
-                                delete_response = await bticino_api.delete_subscribe_c2c_notifications(
+                                delete_response = await bticino_api.delete_subscribe_c2c_notifications(  # pylint: disable=line-too-long
                                     plant_id, sub_id
                                 )
 

--- a/custom_components/bticino_x8000/__init__.py
+++ b/custom_components/bticino_x8000/__init__.py
@@ -101,10 +101,8 @@ async def async_setup_entry(  # pylint: disable=too-many-statements
                                     endpoint,
                                 )
 
-                                delete_response = (
-                                    await bticino_api.delete_subscribe_c2c_notifications(
-                                        plant_id, sub_id
-                                    )
+                                delete_response = await bticino_api.delete_subscribe_c2c_notifications(
+                                    plant_id, sub_id
                                 )
 
                                 if delete_response.get("status_code") == 200:

--- a/custom_components/bticino_x8000/__init__.py
+++ b/custom_components/bticino_x8000/__init__.py
@@ -101,8 +101,10 @@ async def async_setup_entry(  # pylint: disable=too-many-statements
                                     endpoint,
                                 )
 
-                                delete_response = await bticino_api.delete_subscribe_c2c_notifications(
-                                    plant_id, sub_id
+                                delete_response = (
+                                    await bticino_api.delete_subscribe_c2c_notifications(
+                                        plant_id, sub_id
+                                    )
                                 )
 
                                 if delete_response.get("status_code") == 200:

--- a/custom_components/bticino_x8000/climate.py
+++ b/custom_components/bticino_x8000/climate.py
@@ -353,6 +353,9 @@ class BticinoX8000ClimateEntity(ClimateEntity):
                 "setPoint": {"value": self._set_point, "unit": self.temperature_unit},
                 "programs": [{"number": self._program_number[0]["number"]}],
             }
+        else:
+            _LOGGER.error("Invalid hvac_mode: %s", hvac_mode)
+            return
         response = await self._bticino_api.set_chronothermostat_status(
             self._plant_id, self._topology_id, payload
         )
@@ -447,6 +450,9 @@ class BticinoX8000ClimateEntity(ClimateEntity):
                 "activationTime": now_timestamp + "/" + boost_90,
                 "setPoint": {"value": set_pont, "unit": self.temperature_unit},
             }
+        else:
+            _LOGGER.error("Invalid boost_time: %s (must be 30, 60, or 90)", boost_time)
+            return
         response = await self._bticino_api.set_chronothermostat_status(
             self._plant_id, self._topology_id, payload
         )

--- a/custom_components/bticino_x8000/select.py
+++ b/custom_components/bticino_x8000/select.py
@@ -71,7 +71,7 @@ class BticinoBoostSelect(SelectEntity):  # pylint: disable=too-many-instance-att
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/select.py
+++ b/custom_components/bticino_x8000/select.py
@@ -71,7 +71,8 @@ class BticinoBoostSelect(SelectEntity):  # pylint: disable=too-many-instance-att
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(
         self,
         data: dict[str, Any],
         plant_id: str,
@@ -322,7 +323,8 @@ class BticinoProgramSelect(
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/select.py
+++ b/custom_components/bticino_x8000/select.py
@@ -71,8 +71,7 @@ class BticinoBoostSelect(SelectEntity):  # pylint: disable=too-many-instance-att
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         data: dict[str, Any],
         plant_id: str,
@@ -323,8 +322,7 @@ class BticinoProgramSelect(
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/select.py
+++ b/custom_components/bticino_x8000/select.py
@@ -71,7 +71,7 @@ class BticinoBoostSelect(SelectEntity):  # pylint: disable=too-many-instance-att
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         data: dict[str, Any],
         plant_id: str,
@@ -322,7 +322,7 @@ class BticinoProgramSelect(
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/select.py
+++ b/custom_components/bticino_x8000/select.py
@@ -322,7 +322,7 @@ class BticinoProgramSelect(
 
     _attr_should_poll = False  # NO POLLING! Updates via webhook only
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/sensor.py
+++ b/custom_components/bticino_x8000/sensor.py
@@ -380,7 +380,8 @@ class BticinoProgramSensor(BticinoBaseSensor):
 
     _attr_icon = "mdi:calendar-clock"
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/sensor.py
+++ b/custom_components/bticino_x8000/sensor.py
@@ -141,7 +141,7 @@ class BticinoBaseSensor(SensorEntity):
         """Return device info to link with climate entity."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._topology_id)},
-            name=self._thermostat_name,  # Just "Sala", not "Bticino Sala"
+            name=self._thermostat_name,
             manufacturer="Legrand",
             model="X8000",
         )
@@ -380,7 +380,7 @@ class BticinoProgramSensor(BticinoBaseSensor):
 
     _attr_icon = "mdi:calendar-clock"
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/sensor.py
+++ b/custom_components/bticino_x8000/sensor.py
@@ -380,8 +380,7 @@ class BticinoProgramSensor(BticinoBaseSensor):
 
     _attr_icon = "mdi:calendar-clock"
 
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/custom_components/bticino_x8000/sensor.py
+++ b/custom_components/bticino_x8000/sensor.py
@@ -380,7 +380,7 @@ class BticinoProgramSensor(BticinoBaseSensor):
 
     _attr_icon = "mdi:calendar-clock"
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         data: dict[str, Any],
         plant_id: str,

--- a/scripts/check_c2c_subscription.py
+++ b/scripts/check_c2c_subscription.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Script to check if a specific C2C subscription exists on the Bticino server.
+Usage: python3 check_c2c_subscription.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add the custom_components directory to the path
+sys.path.insert(0, str(Path(__file__).parent.parent / "custom_components"))
+
+from bticino_x8000.api import BticinoAPI
+
+
+async def check_subscription(
+    access_token: str,
+    subscription_key: str,
+    subscription_id: str,
+    plant_id: str,
+):
+    """Check if a specific subscription exists."""
+    print(f"🔍 Checking subscription on Bticino server...")
+    print(f"   Plant ID: {plant_id}")
+    print(f"   Subscription ID: {subscription_id}")
+    print()
+
+    # Create API instance
+    api = BticinoAPI(
+        client_id="",  # Not needed for read-only operations
+        client_secret="",
+        subscription_key=subscription_key,
+        access_token=access_token,
+        refresh_token="",
+    )
+
+    # Get all subscriptions
+    print("📡 Fetching all C2C subscriptions from Bticino API...")
+    response = await api.get_subscriptions_c2c_notifications()
+
+    if response.get("status_code") != 200:
+        print(f"❌ Failed to fetch subscriptions: {response}")
+        return False
+
+    all_subscriptions = response.get("data", [])
+    print(f"✅ Found {len(all_subscriptions)} total subscription(s)\n")
+
+    # Find our subscription
+    found = False
+    for sub in all_subscriptions:
+        sub_id = sub.get("subscriptionId")
+        endpoint = sub.get("EndPointUrl")
+        sub_plant_id = sub.get("plantId")
+
+        if sub_id == subscription_id:
+            found = True
+            print(f"✅ SUBSCRIPTION FOUND!")
+            print(f"   Subscription ID: {sub_id}")
+            print(f"   Plant ID: {sub_plant_id}")
+            print(f"   Endpoint URL: {endpoint}")
+            print()
+            print("✅ The subscription is correctly registered on Bticino server!")
+            print()
+            print("If webhooks are not arriving, the issue is likely:")
+            print("  1. Network/firewall blocking incoming requests")
+            print("  2. Reverse proxy (Nginx/Traefik) not forwarding to Home Assistant")
+            print("  3. SSL certificate issues")
+            print()
+            print("Test your webhook URL manually:")
+            print(f"  curl -X POST {endpoint} -H 'Content-Type: application/json' -d '{{\"test\":\"manual\"}}' -v")
+            return True
+
+    if not found:
+        print(f"❌ SUBSCRIPTION NOT FOUND!")
+        print(f"   The subscription ID '{subscription_id}' is saved in Home Assistant,")
+        print(f"   but it does NOT exist on the Bticino server.")
+        print()
+        print("This is a 'ghost' subscription. Webhooks will NOT work.")
+        print()
+        print("🔧 Solution:")
+        print("   1. Remove and re-add the Bticino X8000 integration in Home Assistant")
+        print("   2. This will create a new, working subscription")
+        print()
+        print("Other subscriptions found on the server:")
+        for sub in all_subscriptions:
+            print(f"  - ID: {sub.get('subscriptionId')}")
+            print(f"    Plant: {sub.get('plantId')}")
+            print(f"    Endpoint: {sub.get('EndPointUrl')}")
+            print()
+
+    return False
+
+
+async def main():
+    """Main function."""
+    print("=" * 70)
+    print("🔍 Bticino X8000 - C2C Subscription Checker")
+    print("=" * 70)
+    print()
+
+    # Configuration from the production system
+    # REPLACE THESE VALUES WITH YOUR OWN
+    access_token = input("Enter your access_token (from config_entries): ").strip()
+    if not access_token:
+        print("❌ Access token is required")
+        return
+
+    subscription_key = input(
+        "Enter your subscription_key (from config_entries, default: f38af44bf1e8488188165be61a4c7ad7): "
+    ).strip()
+    if not subscription_key:
+        subscription_key = "f38af44bf1e8488188165be61a4c7ad7"
+
+    subscription_id = input(
+        "Enter the subscription_id to check (default: cacf4105-83ca-4471-9e5a-1cf0c7f5c0c8): "
+    ).strip()
+    if not subscription_id:
+        subscription_id = "cacf4105-83ca-4471-9e5a-1cf0c7f5c0c8"
+
+    plant_id = input(
+        "Enter your plant_id (default: f1160185-b7a4-7b71-e053-27182d0a110d): "
+    ).strip()
+    if not plant_id:
+        plant_id = "f1160185-b7a4-7b71-e053-27182d0a110d"
+
+    print()
+
+    await check_subscription(
+        access_token=access_token,
+        subscription_key=subscription_key,
+        subscription_id=subscription_id,
+        plant_id=plant_id,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+


### PR DESCRIPTION
Implement automatic cleanup of orphaned C2C webhook subscriptions when receiving 409 Conflict error during registration.

Logic:
1. When 409 Conflict occurs during C2C subscription
2. GET all existing subscriptions for the plant
3. Filter Home Assistant subscriptions (containing '/api/webhook/')
4. DELETE all HA subscriptions for that plant
5. Retry the subscription registration

Safety:
- Only deletes subscriptions with '/api/webhook/' in endpoint
- Does NOT touch subscriptions from other apps (Alexa, Google Home, etc.)
- Only deletes subscriptions for the specific plant being configured
- Detailed logging with emoji indicators for easy debugging

Benefits:
- Fixes 409 errors from previous failed/incomplete uninstalls
- No manual intervention required
- Prevents accumulation of orphaned subscriptions
- Users no longer need to manually run cleanup script

Logging:
- ⚠️  Warning when 409 detected
- 🔍 Info on subscriptions found
- 🗑️  Debug on each deletion attempt
- ✅ Success confirmation
- 🔄 Retry notification

Related: Companion standalone cleanup script in scripts/cleanup_c2c_subscriptions.py for users who need manual control or debugging.